### PR TITLE
Added dedicated claim dialect support

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/twitter/TwitterAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/twitter/TwitterAuthenticator.java
@@ -123,7 +123,12 @@ public class TwitterAuthenticator extends AbstractApplicationAuthenticator imple
 
     @Override
     public String getClaimDialectURI() {
-        return TwitterAuthenticatorConstants.CLAIM_DIALECT_URI;
+        String claimDialectUri = super.getClaimDialectURI();
+        if (StringUtils.isNotEmpty(claimDialectUri)) {
+            return claimDialectUri;
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -162,16 +167,18 @@ public class TwitterAuthenticator extends AbstractApplicationAuthenticator imple
         if (userClaims != null) {
             Map<ClaimMapping, String> claims = new HashMap<>();
             for (Map.Entry<String, Object> entry : userClaims.entrySet()) {
-                claims.put(ClaimMapping.build(TwitterAuthenticatorConstants.CLAIM_DIALECT_URI + "/" +
-                                entry.getKey(), TwitterAuthenticatorConstants.CLAIM_DIALECT_URI + "/" +
-                                entry.getKey(), null, false),
+                String claimDialectUri = getClaimDialectURI();
+                if (claimDialectUri == null) {
+                    claimDialectUri = "";
+                } else {
+                    claimDialectUri += "/";
+                }
+                String claimUri =  claimDialectUri + entry.getKey();
+                claims.put(ClaimMapping.build(claimUri, claimUri, null, false),
                         entry.getValue().toString());
                 if (log.isDebugEnabled() &&
                         IdentityUtil.isTokenLoggable(IdentityConstants.IdentityTokens.USER_CLAIMS)) {
-                    log.debug("Adding claim mapping : " + TwitterAuthenticatorConstants.CLAIM_DIALECT_URI + "/" +
-                            entry.getKey() + " <> " + TwitterAuthenticatorConstants.CLAIM_DIALECT_URI + "/" +
-                            entry.getKey() + " : " +
-                            entry.getValue());
+                    log.debug("Adding claim mapping : " + claimUri + " <> " + claimUri + " : " + entry.getValue());
                 }
             }
             if (StringUtils.isBlank(context.getExternalIdP().getIdentityProvider().getClaimConfig().getUserClaimURI())) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/twitter/TwitterAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/twitter/TwitterAuthenticator.java
@@ -155,7 +155,7 @@ public class TwitterAuthenticator extends AbstractApplicationAuthenticator imple
         }
     }
 
-    private void buildClaims(AuthenticationContext context, String jsonObject)
+    public void buildClaims(AuthenticationContext context, String jsonObject)
             throws ApplicationAuthenticatorException, JSONException {
         Map<String, Object> userClaims;
         userClaims = JSONUtils.parseJSON(jsonObject);
@@ -168,8 +168,10 @@ public class TwitterAuthenticator extends AbstractApplicationAuthenticator imple
                         entry.getValue().toString());
                 if (log.isDebugEnabled() &&
                         IdentityUtil.isTokenLoggable(IdentityConstants.IdentityTokens.USER_CLAIMS)) {
-                    log.debug("Adding claim mapping : " + entry.getKey() + " <> " + entry.getKey() + " : "
-                            + entry.getValue());
+                    log.debug("Adding claim mapping : " + TwitterAuthenticatorConstants.CLAIM_DIALECT_URI + "/" +
+                            entry.getKey() + " <> " + TwitterAuthenticatorConstants.CLAIM_DIALECT_URI + "/" +
+                            entry.getKey() + " : " +
+                            entry.getValue());
                 }
             }
             if (StringUtils.isBlank(context.getExternalIdP().getIdentityProvider().getClaimConfig().getUserClaimURI())) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/twitter/TwitterAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/twitter/TwitterAuthenticator.java
@@ -121,6 +121,10 @@ public class TwitterAuthenticator extends AbstractApplicationAuthenticator imple
         return TwitterAuthenticatorConstants.TWITTER_CALLBACK_URL;
     }
 
+    @Override
+    public String getClaimDialectURI() {
+        return TwitterAuthenticatorConstants.CLAIM_DIALECT_URI;
+    }
 
     /**
      * Process the response of the Twitter
@@ -151,15 +155,17 @@ public class TwitterAuthenticator extends AbstractApplicationAuthenticator imple
         }
     }
 
-    public void buildClaims(AuthenticationContext context, String jsonObject)
+    private void buildClaims(AuthenticationContext context, String jsonObject)
             throws ApplicationAuthenticatorException, JSONException {
         Map<String, Object> userClaims;
         userClaims = JSONUtils.parseJSON(jsonObject);
         if (userClaims != null) {
-            Map<ClaimMapping, String> claims = new HashMap<ClaimMapping, String>();
+            Map<ClaimMapping, String> claims = new HashMap<>();
             for (Map.Entry<String, Object> entry : userClaims.entrySet()) {
-                claims.put(ClaimMapping.build(entry.getKey(), entry.getKey(), null,
-                        false), entry.getValue().toString());
+                claims.put(ClaimMapping.build(TwitterAuthenticatorConstants.CLAIM_DIALECT_URI + "/" +
+                                entry.getKey(), TwitterAuthenticatorConstants.CLAIM_DIALECT_URI + "/" +
+                                entry.getKey(), null, false),
+                        entry.getValue().toString());
                 if (log.isDebugEnabled() &&
                         IdentityUtil.isTokenLoggable(IdentityConstants.IdentityTokens.USER_CLAIMS)) {
                     log.debug("Adding claim mapping : " + entry.getKey() + " <> " + entry.getKey() + " : "

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/twitter/TwitterAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/twitter/TwitterAuthenticatorConstants.java
@@ -32,4 +32,6 @@ public class TwitterAuthenticatorConstants {
     public static final String TWITTER_OAUTH_VERIFIER = "oauth_verifier";
     public static final String TWITTER_CALLBACK_URL = "https://localhost:9443/commonauth";
     public static final String CLAIM_ID = "id";
+
+    public static final String CLAIM_DIALECT_URI = "http://wso2.org/twitter/claims";
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/twitter/TwitterAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/twitter/TwitterAuthenticatorConstants.java
@@ -32,6 +32,4 @@ public class TwitterAuthenticatorConstants {
     public static final String TWITTER_OAUTH_VERIFIER = "oauth_verifier";
     public static final String TWITTER_CALLBACK_URL = "https://localhost:9443/commonauth";
     public static final String CLAIM_ID = "id";
-
-    public static final String CLAIM_DIALECT_URI = "http://wso2.org/twitter/claims";
 }


### PR DESCRIPTION
This PR intends to add dedicated claim dialect support for twitter connector. If the dedicated claim dialect behavior needs enabled, the application-authentication.xml needs to be config as below.

ex:- 
&lt;AuthenticatorConfig name="TwitterAuthenticator" enabled="true"&gt;
			&lt;Parameter name="ClaimDialectUri"&gt;http://wso2.org/twitter/claims &lt;/Parameter&gt;
	&lt;/AuthenticatorConfig&gt;

After that add dedicated claim dialect in management console with above given uri and relevant mapping

Public Jira :- https://wso2.org/jira/browse/IDENTITY-6239
