### PR TITLE
Tenant qualify default callback URL

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -63,8 +63,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/twitter/TwitterAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/twitter/TwitterAuthenticator.java
@@ -40,6 +40,8 @@ import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.base.IdentityConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import twitter4j.JSONException;
 import twitter4j.Twitter;
 import twitter4j.TwitterException;
@@ -172,7 +174,12 @@ public class TwitterAuthenticator extends AbstractApplicationAuthenticator imple
         if (StringUtils.isNotEmpty(authenticatorProperties.get(IdentityApplicationConstants.OAuth2.CALLBACK_URL))) {
             return authenticatorProperties.get(IdentityApplicationConstants.OAuth2.CALLBACK_URL);
         }
-        return IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, true, true);
+        try {
+            return ServiceURLBuilder.create().addPath(FrameworkConstants.COMMONAUTH).build()
+                    .getAbsolutePublicURL();
+        } catch (URLBuilderException e) {
+            throw new RuntimeException("Error occurred while building URL.", e);
+        }
     }
 
     @Override

--- a/component/setup.txt
+++ b/component/setup.txt
@@ -2,13 +2,13 @@ Product: WSO2 IS authenticator for Twitter
 Pre-requisites:
 
 - Maven 3.x
-- Java 1.7 or above
+- Java 1.8 or above
 
 Tested Platform: 
 
 - Mac OSx 10.9
 - WSO2 IS 5.1.0
-- Java 1.7
+- Java 1.8
 
 Do the following:
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
             <version>${carbon.identity.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+            <version>${carbon.identity.framework.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity</groupId>
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
             <version>${carbon.identity.version}</version>
@@ -228,8 +233,8 @@
                 <version>2.3.1</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -318,6 +323,7 @@
     </distributionManagement>
     <properties>
         <carbon.identity.version>5.0.7</carbon.identity.version>
+        <carbon.identity.framework.version>5.25.260</carbon.identity.framework.version>
         <carbon.identity.framework.package.import.version.range>[5.0.0, 7.0.0)</carbon.identity.framework.package.import.version.range>
         <commons-logging.version>4.4.3</commons-logging.version>
         <carbon.kernel.version>4.4.3</carbon.kernel.version>


### PR DESCRIPTION
If the commonauth URL is not configured in the Identity provider, the default commonauth URL will be resolved internally. This PR uses the ServerURLBuilder to build this with the tenant domain to support tenant qualified URLs.

Related issue: https://github.com/wso2/product-is/issues/9006